### PR TITLE
chore: Add timestamp to results JSON

### DIFF
--- a/helper_tools/results_processor.py
+++ b/helper_tools/results_processor.py
@@ -15,6 +15,7 @@
 import argparse
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -427,6 +428,7 @@ def process_json_data(run_infos: list[RunInfo]) -> dict:
     }
 
     result_dict["version"] = RESULTS_VERSION
+    result_dict["created_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%d--%H:%M:%S")
 
     for run_info in run_infos:
         benchmark_name = normalize_benchmark_name(run_info)


### PR DESCRIPTION
## Summary
Add timestamp in the results JSON.
`"created_at"` field is used to hold the timestamp.