### PR TITLE
chore: remove model from benchmark configs

### DIFF
--- a/configs/bias/reddit_bias.yaml
+++ b/configs/bias/reddit_bias.yaml
@@ -30,7 +30,6 @@ data_config_religion2: &data_config_religion2
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "reddit_bias"

--- a/configs/calibration/calibration_big_bench.yaml
+++ b/configs/calibration/calibration_big_bench.yaml
@@ -13,7 +13,6 @@ metric_config: &metric_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "calibration_big_bench"

--- a/configs/calibration/calibration_big_bench_i_know.yaml
+++ b/configs/calibration/calibration_big_bench_i_know.yaml
@@ -13,7 +13,6 @@ metric_config: &metric_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "calibration_big_bench_i_know"

--- a/configs/capabilities/ai2_reasoning.yaml
+++ b/configs/capabilities/ai2_reasoning.yaml
@@ -16,7 +16,6 @@ metric_config: &metric_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "ai2_reasoning"

--- a/configs/capabilities/hellaswag.yaml
+++ b/configs/capabilities/hellaswag.yaml
@@ -12,7 +12,6 @@ metric_config: &metric_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 42
   benchmark_configs:
     - name: "hellaswag"

--- a/configs/capabilities/human_eval.yaml
+++ b/configs/capabilities/human_eval.yaml
@@ -1,7 +1,6 @@
 
 config:
   run_id: 1
-  model: !include models/human_eval_model.yaml
   seed: 36
   benchmark_configs:
     - name: "human_eval"

--- a/configs/capabilities/mmlu.yaml
+++ b/configs/capabilities/mmlu.yaml
@@ -13,7 +13,6 @@ metric_config: &metric_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "mmlu"

--- a/configs/capabilities/truthful_qa_mc2.yaml
+++ b/configs/capabilities/truthful_qa_mc2.yaml
@@ -9,7 +9,6 @@ data_config: &data_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "truthful_qa_mc2"

--- a/configs/consistency/forecasting_consistency.yaml
+++ b/configs/consistency/forecasting_consistency.yaml
@@ -5,7 +5,6 @@ data_config: &data_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "forecast_consistency"

--- a/configs/consistency/self_check_consistency.yaml
+++ b/configs/consistency/self_check_consistency.yaml
@@ -5,7 +5,6 @@ data_config: &data_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "self_check_consistency"

--- a/configs/cybersecurity/instruction_goal_hijacking.yaml
+++ b/configs/cybersecurity/instruction_goal_hijacking.yaml
@@ -4,7 +4,6 @@ data_config: &data_config
     
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "instruction_goal_hijacking"

--- a/configs/cybersecurity/multiturn_goal_hijacking.yaml
+++ b/configs/cybersecurity/multiturn_goal_hijacking.yaml
@@ -12,7 +12,6 @@ data_configs: &data_configs
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "multiturn_goal_hijacking"

--- a/configs/fairness/bbq.yaml
+++ b/configs/fairness/bbq.yaml
@@ -5,7 +5,6 @@ data_config: &data_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "bbq"

--- a/configs/fairness/bold.yaml
+++ b/configs/fairness/bold.yaml
@@ -5,7 +5,6 @@ data_config: &data_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "bold"

--- a/configs/human_deception/human_deception.yaml
+++ b/configs/human_deception/human_deception.yaml
@@ -3,7 +3,6 @@ data_config: &data_config
     
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "human_deception"

--- a/configs/memorization/memorization.yaml
+++ b/configs/memorization/memorization.yaml
@@ -4,7 +4,6 @@ data_config: &data_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "memorization"

--- a/configs/robustness/boolq_contrast_robustness.yaml
+++ b/configs/robustness/boolq_contrast_robustness.yaml
@@ -13,7 +13,6 @@ metric_config: &metric_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "boolq_contrast_robustness"

--- a/configs/robustness/imdb_contrast_robustness.yaml
+++ b/configs/robustness/imdb_contrast_robustness.yaml
@@ -13,7 +13,6 @@ metric_config: &metric_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "imdb_contrast_robustness"

--- a/configs/robustness/mmlu_robustness.yaml
+++ b/configs/robustness/mmlu_robustness.yaml
@@ -13,7 +13,6 @@ metric_config: &metric_config
 
 config:
   run_id: 1
-  model: !include models/default_model.yaml
   seed: 36
   benchmark_configs:
     - name: "mmlu_robustness"


### PR DESCRIPTION
Remove `model` entry from benchmark configs. There are no use cases where a benchmark would run with a default model. In contrast, keeping it in the config is confusing as this is logged in the eval results (even though it's not the model that is being evaluated).