### PR TITLE
Add filtering by task attributes

### DIFF
--- a/src/complai/_cli/eval.py
+++ b/src/complai/_cli/eval.py
@@ -68,6 +68,14 @@ def eval_command(
             envvar="COMPLAI_TASKS_TO_SKIP",
         ),
     ] = None,
+    task_filter: Annotated[
+        list[str] | None,
+        typer.Option(
+            "-F",
+            "--task-filter",
+            help="Filter tasks by attribute (e.g. `-f technical_requirement='Capabilities, Performance, and Limitations'`).",
+        ),
+    ] = None,
     task_args: Annotated[
         list[str],
         typer.Option(
@@ -322,7 +330,10 @@ def eval_command(
 ) -> None:
     """Run tasks."""
     # Get TaskInfo objects from task names
-    task_infos: list[TaskInfo] = get_task_infos(tasks, tasks_to_skip)
+    parsed_task_filters = parse_cli_config(task_filter, None)
+    task_infos: list[TaskInfo] = get_task_infos(
+        tasks, tasks_to_skip, parsed_task_filters
+    )
 
     # Apply display monkey patch
     patch_display_results()

--- a/src/complai/_cli/utils.py
+++ b/src/complai/_cli/utils.py
@@ -26,7 +26,7 @@ def get_complai_tasks(
 
 
 def get_task_infos_from_task_names(
-    task_names: list[str], tasks_to_skip: list[str]
+    task_names: list[str], tasks_to_skip: list[str], task_filter: dict[str, str] | None
 ) -> list[TaskInfo]:
     """
     Get TaskInfo objects from a list of task names.
@@ -35,6 +35,7 @@ def get_task_infos_from_task_names(
         tasks_names (list[str]): List of task names to retrieve TaskInfo for. If empty,
             all available tasks are returned.
         tasks_to_skip (list[str]): List of task names to skip.
+        task_filter (dict[str, str] | None): Filter tasks by attribute (e.g. `-f technical_requirement='Capabilities, Performance, and Limitations'`).
 
     Raises:
         typer.BadParameter: If one of the task names is not valid.
@@ -46,6 +47,11 @@ def get_task_infos_from_task_names(
     def filter(task: TaskInfo) -> bool:
         if task.name in tasks_to_skip:
             tasks_to_skip.remove(task.name)
+            return False
+
+        if task_filter and not any(
+            task.attribs.get(key) == value for key, value in task_filter.items()
+        ):
             return False
 
         return not task_names or task.name in task_names
@@ -83,13 +89,16 @@ def parse_tasks(tasks: str | None) -> list[str]:
     return task_names
 
 
-def get_task_infos(tasks: str | None, tasks_to_skip: str | None) -> list[TaskInfo]:
+def get_task_infos(
+    tasks: str | None, tasks_to_skip: str | None, task_filter: dict[str, str] | None
+) -> list[TaskInfo]:
     """
     Get TaskInfo objects for the specified tasks.
 
     Args:
         tasks (str | None): Comma-separated list of task names. If None, all available tasks are returned.
         tasks_to_skip (str | None): Comma-separated list of task names to skip. If None, no tasks are skipped.
+        task_filter (dict[str, str] | None): Filter tasks by attribute (e.g. `-f technical_requirement='Capabilities, Performance, and Limitations'`).
 
     Returns:
         list[TaskInfo]: List of TaskInfo objects for the specified tasks.
@@ -97,7 +106,7 @@ def get_task_infos(tasks: str | None, tasks_to_skip: str | None) -> list[TaskInf
     task_names = parse_tasks(tasks)
     tasks_to_skip_names = parse_tasks(tasks_to_skip)
 
-    return get_task_infos_from_task_names(task_names, tasks_to_skip_names)
+    return get_task_infos_from_task_names(task_names, tasks_to_skip_names, task_filter)
 
 
 def patch_display_results() -> None:


### PR DESCRIPTION
Ads filtering by task attributes. E.g. allows running
```
complai eval -F technical_requirement='Robustness and Predictability'
```