### PR TITLE
boolq_contrast: report stderr alongside the grouped accuracy

### DIFF
--- a/src/complai/tasks/boolq_contrast/boolq_contrast.py
+++ b/src/complai/tasks/boolq_contrast/boolq_contrast.py
@@ -145,7 +145,14 @@ def stderr() -> Metric:
         # quantity accuracy() reports. Questions are the independent units;
         # the contrast samples within a question share its paragraph and are
         # aggregated before the SE is taken.
-        return sem(grouped_accuracies(scores), ddof=1)
+        accuracies = grouped_accuracies(scores)
+        # A spread needs two independent units. A single question — reachable
+        # with --limit 1 — leaves ddof=1 dividing by zero, which scipy answers
+        # with nan behind a SmallSampleWarning that an eval run will not show.
+        # Report the nan directly, so the number is absent rather than invented.
+        if len(accuracies) < 2:
+            return float("nan")
+        return float(sem(accuracies, ddof=1))
 
     return metric
 

--- a/src/complai/tasks/boolq_contrast/boolq_contrast.py
+++ b/src/complai/tasks/boolq_contrast/boolq_contrast.py
@@ -114,22 +114,38 @@ def boolq_contrastset_dataset(num_contrasts: int, contrast_seed: int) -> Dataset
     )
 
 
+def grouped_accuracies(scores: list[SampleScore]) -> list[float]:
+    # Aggregate samples with the same original question (group by id)
+    correct: dict[int, int] = defaultdict(int)
+    total: dict[int, int] = defaultdict(int)
+    for score in scores:
+        id = cast(dict, score.sample_metadata)["id"]
+        if score.score.as_bool():
+            correct[id] += 1
+        total[id] += 1
+
+    # Calculate accuracy for each original question
+    return [correct[id] / total[id] for id in total]
+
+
 @metric
 def accuracy() -> Metric:
     def metric(scores: list[SampleScore]) -> float:
-        # Aggregate samples with the same original question (group by id)
-        correct: dict[int, int] = defaultdict(int)
-        total: dict[int, int] = defaultdict(int)
-        for score in scores:
-            id = cast(dict, score.sample_metadata)["id"]
-            if score.score.as_bool():
-                correct[id] += 1
-            total[id] += 1
+        return np.mean(grouped_accuracies(scores), dtype=float)
 
-        # Calculate accuracy for each original question
-        accuracies = [correct[id] / total[id] for id in total]
+    return metric
 
-        return np.mean(accuracies, dtype=float)
+
+@metric
+def stderr() -> Metric:
+    from scipy.stats import sem
+
+    def metric(scores: list[SampleScore]) -> float:
+        # Standard error over the per-question accuracies, i.e. of the exact
+        # quantity accuracy() reports. Questions are the independent units;
+        # the contrast samples within a question share its paragraph and are
+        # aggregated before the SE is taken.
+        return sem(grouped_accuracies(scores), ddof=1)
 
     return metric
 
@@ -147,5 +163,5 @@ def boolq_contrast(num_contrasts: int = 3, contrast_seed: int = 0) -> Task:
         dataset=boolq_contrastset_dataset(num_contrasts, contrast_seed),
         solver=[system_message(BOOLQ_SYSTEM_PROMPT), generate()],
         scorer=match(location="begin", ignore_case=True),
-        metrics=[accuracy()],
+        metrics=[accuracy(), stderr()],
     )

--- a/src/tests/test_boolq_contrast_metrics.py
+++ b/src/tests/test_boolq_contrast_metrics.py
@@ -1,0 +1,89 @@
+import math
+import warnings
+
+from inspect_ai.scorer import SampleScore
+from inspect_ai.scorer import Score
+
+from complai.tasks.boolq_contrast.boolq_contrast import accuracy
+from complai.tasks.boolq_contrast.boolq_contrast import grouped_accuracies
+from complai.tasks.boolq_contrast.boolq_contrast import stderr
+
+
+def sample_score(question_id: int, correct: bool) -> SampleScore:
+    """Build a scored sample as the metrics actually receive it.
+
+    The epoch reducer maps "C"/"I" to 1.0/0 before metrics run, even for a
+    single epoch, so a test that feeds raw "C"/"I" strings would exercise a
+    path production never takes (`Score(value="I").as_bool()` is True).
+    """
+    return SampleScore(
+        score=Score(value=1.0 if correct else 0), sample_metadata={"id": question_id}
+    )
+
+
+class TestGroupedAccuracies:
+    """Test the per-question aggregation both metrics are built on."""
+
+    def test_groups_by_question_id(self) -> None:
+        """Each original question contributes one accuracy, whatever its size."""
+        scores = (
+            [sample_score(0, True)] * 3
+            + [sample_score(1, True), sample_score(1, False)]
+            + [sample_score(2, False)] * 3
+        )
+        assert sorted(grouped_accuracies(scores)) == [0.0, 0.5, 1.0]
+
+
+class TestAccuracy:
+    """Test that accuracy() averages questions, not samples."""
+
+    def test_is_mean_of_question_accuracies(self) -> None:
+        """A large correct question does not outweigh a small wrong one."""
+        scores = [sample_score(0, True)] * 5 + [sample_score(1, False)]
+        # Pooled over samples this would be 5/6; over questions it is 1/2.
+        assert accuracy()(scores) == 0.5
+
+
+class TestStderr:
+    """Test the standard error of the quantity accuracy() reports."""
+
+    def test_matches_the_closed_form(self) -> None:
+        """Accuracies [1.0, 0.5, 0.0] have sd 0.5, so the SE is 0.5/sqrt(3)."""
+        scores = (
+            [sample_score(0, True)] * 3
+            + [sample_score(1, True), sample_score(1, False)]
+            + [sample_score(2, False)] * 3
+        )
+        assert stderr()(scores) == 0.5 / math.sqrt(3)
+
+    def test_is_zero_when_every_question_agrees(self) -> None:
+        """No spread between questions is a real zero, not a missing value."""
+        scores = [sample_score(i, True) for i in range(3)]
+        assert stderr()(scores) == 0.0
+
+    def test_is_nan_for_a_single_question(self) -> None:
+        """One question supports no spread estimate, so report nan, not 0.0.
+
+        Reachable with --limit 1. Returning a number here would state a
+        precision the run cannot support.
+        """
+        scores = [sample_score(0, True), sample_score(0, False)]
+        assert len(grouped_accuracies(scores)) == 1
+        assert math.isnan(stderr()(scores))
+
+    def test_is_nan_for_no_questions(self) -> None:
+        """An empty run has nothing to measure."""
+        assert math.isnan(stderr()([]))
+
+    def test_degenerate_input_is_handled_here_not_by_scipy(self) -> None:
+        """The nan is this function's contract, not scipy's current behaviour.
+
+        `sem([x], ddof=1)` also returns nan, but only after dividing by a zero
+        degrees-of-freedom behind a SmallSampleWarning — a path whose result has
+        changed across scipy versions. Asserting the warning is absent is what
+        distinguishes the explicit guard from relying on that behaviour.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert math.isnan(stderr()([sample_score(0, True)]))
+            assert isinstance(stderr()([sample_score(0, True)]), float)


### PR DESCRIPTION
## What

`boolq_contrast` reported its grouped accuracy with no uncertainty estimate. Every other custom-scored task in the suite (`imdb_contrast`, `llm_rules`, `cab`, `hle`, `ifbench`, `instruction_goal_hijacking`, `realtoxicityprompts`, `self_check_consistency`) already reports `stderr()` next to its headline metric — this brings `boolq_contrast` in line.

## Why a custom stderr rather than the builtin

This task's `accuracy()` is a **mean of per-question accuracies** (contrast samples grouped by `id`), not a pooled per-sample mean — with unequal group sizes the two differ. The builtin `stderr()` would therefore estimate the SE of a *different* quantity than the one reported. Following the in-repo precedent of `self_check_consistency` (custom `stderr` matched to its custom `accuracy`), the SE here is computed over the same per-question accuracy list the headline metric averages, with questions as the independent units. The shared grouping is factored into `grouped_accuracies()` so the two metrics cannot drift apart.

At the default BoolQ contrast-set size this puts a ±2·SE band of roughly a few percentage points around the reported score — without it, model-to-model differences inside that band read as real.

## Verification

- Metric logic executed against real `inspect_ai` `SampleScore` objects (0.3.254) in a standalone harness: grouped accuracy unchanged on mixed/degenerate/skewed-group cases; `stderr` equals `sem(per-question accuracies, ddof=1)` analytically (0.5/√3 on the 3-question fixture); the skewed-group case (pooled 5/6 vs grouped ½) confirms the metric is mean-of-group-means, which is what motivates the matched SE.
- `ruff check` clean on the touched path; behavior of `accuracy()` is unchanged (pure refactor + additive metric).
- Not run: a full `eval_set` against a live model (no API creds in this environment) — the metric surface is the only change.
